### PR TITLE
Remove warnings in Elixir 1.5.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule UriTemplate.Mixfile do
      description: "RFC 6570 complient URI template processor",
      version: "1.2.0",
      elixir: "~> 1.0",
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   defp git_files do
@@ -18,7 +18,7 @@ defmodule UriTemplate.Mixfile do
   end
 
   defp package do
-    [ files: git_files,
+    [ files: git_files(),
       licenses: ["http://opensource.org/licenses/MIT"],
       contributors: ["Peter Williams", "Julius Beckmann"],
       links: %{"homepage": "http://github.com/pezra/ex-uri-template"} ]


### PR DESCRIPTION
When I upgraded to Elixir 1.5.2, the console logged a few warnings:

* warning: variable "deps" does not exist and is being expanded to
  "deps()", please use parentheses to remove the ambiguity or change the
  variable name
* warning: variable "package" does not exist and is being expanded to
  "package()", please use parentheses to remove the ambiguity or change
  the variable name
* warning: variable "git_files" does not exist and is being expanded to
  "git_files()", please use parentheses to remove the ambiguity or
  change the variable name

I added some parentheses to remove the warnings.

**Note**: I couldn't get the tests running. I don't think these changes will have broken anything, but the test suite should be run against these changes.